### PR TITLE
Cria botões para auxílio no cadastro de notificações

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     lino:
         # If you want to development and use another image,
         # change the image to the Dockerfile that corresponds to the one you want to use.
-        image: guila/lino:latest
+        build:
+            context: .
+            dockerfile: docker/Telegram.Dockerfile
         ports:
             - 5002:5002
         volumes:
@@ -12,15 +14,15 @@ services:
         stdin_open: true
         tty: true
         environment:
-           - TRAINING_EPOCHS: ${TRAINING_EPOCHS}
-           - TELEGRAM_ACCESS_TOKEN: ${TELEGRAM_ACCESS_TOKEN}
-           - VERIFY: ${VERIFY}
-           - PSID: ${PSID}
-           - FACEBOOK_ACCESS_TOKEN: ${FACEBOOK_ACCESS_TOKEN}
-           - SECRET: ${SECRET}
-           - WEBHOOK_URL: ${WEBHOOK_URL}
-           - TELEGRAM_DB_URI: ${TELEGRAM_DB_URI}
-           - FACEBOOK_DB_URI: ${FACEBOOK_DB_URI}
+           - TRAINING_EPOCHS=300
+           - TELEGRAM_ACCESS_TOKEN=677504218:AAHaga656yF0tqY0vfH5NgALds6UFn0VEek
+           - VERIFY=ulib_fga_bot
+           - PSID=303317230254781
+           - FACEBOOK_ACCESS_TOKEN=EAANoEk6bk1MBACfBTZACN42HlDbVZCg5cRqoyZBwfZALh0mZCvd3hXDPuJl1bPijVQPXZBqfUvduVTKh96PFSKpGC2lrHhgb5kZCRMkkZByHtu0RQKUTM6P8OTnZCvGyfzinCsg64rbUoVN4MjaOBEblDzZBuSDyooMj98ZB5tJ3q8EXwZDZD
+           - SECRET=9faf1e57e1d429ac42473796a8eb0849
+           - WEBHOOK_URL=https://96fffef2.ngrok.io/webhook
+           - TELEGRAM_DB_URI=mongodb://mongo_telegram:27010/lino_telegram
+           - FACEBOOK_DB_URI=mongodb://mongo_facebook:27011/lino_facebook
         # bot credentials in train.py or another train file.
         depends_on:
             - cronjob
@@ -31,7 +33,7 @@ services:
         image: mongo:latest
         command: mongod --port 27010
         volumes:
-            - /l/mongo_telegram/mongo_telegram_db:/data/db
+            - /tmp:/data/db
         ports:
             - 27010:27010
 
@@ -39,7 +41,7 @@ services:
         image: mongo:latest
         command: mongod --port 27011
         volumes:
-            - /l/mongo_facebook/mongo_facebook_db:/data/db
+            - /tmp:/data/db
         ports:
             - 27011:27011
 
@@ -50,11 +52,11 @@ services:
         stdin_open: true
         tty: true
         environment:
-            - URI_TELEGRAM: ${URI_TELEGRAM}
-            - URI_FACEBOOK: ${URI_FACEBOOK}
-            - TELEGRAM_ACCESS_TOKEN: ${TELEGRAM_ACCESS_TOKEN}
-            - FACEBOOK_ACCESS_TOKEN: ${FACEBOOK_ACCESS_TOKEN}
-            - PSID: ${PSID}
+            - URI_TELEGRAM=mongodb://mongo_telegram:27010/lino_telegram
+            - URI_FACEBOOK=AAA
+            - TELEGRAM_ACCESS_TOKEN=677504218:AAHaga656yF0tqY0vfH5NgALds6UFn0VEek
+            - FACEBOOK_ACCESS_TOKEN=AAA
+            - PSID=AAA
         depends_on:
             - webcrawler
             - mongo_telegram
@@ -70,6 +72,6 @@ services:
     mongo_ru:
         image: mongo:latest
         volumes:
-            - /l/crawler/crawler_db:/data/db
+            - /tmp:/data/db
         ports:
             - 27017:27017

--- a/rasa/actions/notifications/buttons_notification.py
+++ b/rasa/actions/notifications/buttons_notification.py
@@ -1,5 +1,4 @@
 import os
-from pymongo import MongoClient
 from rasa_core.actions.action import Action
 
 # If you want to use your own bot to development add the bot token as
@@ -10,23 +9,40 @@ FACEBOOK_ACCESS_TOKEN = os.getenv('FACEBOOK_ACCESS_TOKEN', '')
 TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', '')
 FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', '')
 
+
 class ActionButtonsNotification(Action):
     def name(self):
         return "action_buttons_notification"
 
     def run(self, dispatcher, tracker, domain):
-        buttons = self.build_buttons_telegram()
-        mensagem = 'SHABLAW'
-        buttons = self.build_buttons_facebook()
-        elements = self.build_facebook_elements(buttons)
-        dispatcher.utter_custom_message(*elements)
+        buttons_facebook = None
+        buttons_telegram = None
+
+        try:
+            message = 'Qual das opções você deseja?'
+            buttons_telegram = self.build_buttons_telegram()
+            dispatcher.utter_button_message(message,
+                                            buttons_telegram,
+                                            button_type="custom")
+        except ValueError as valueException:
+            print(valueException + ': on Telegram')
+
+        if not buttons_telegram:
+            try:
+                buttons_facebook = self.build_buttons_facebook()
+                elements = self.build_facebook_elements(buttons_facebook)
+                dispatcher.utter_custom_message(*elements)
+            except ValueError as valueException:
+                print(valueException + ': on Messenger')
+
         return []
 
     def build_button_dict(self):
         return [
-            ('Alerta da Comunidade', 'alerta da comunidade'),
-            ('Cardápio Diario','dia'),
-            ('Cardápio Semanal', 'semana'),
+            ('Alerta da Comunidade',
+             'alerta da comunidade'),
+            ('Cardápio do Dia', 'dia'),
+            ('Cardápio da Semana', 'semana'),
             ('Café da Manhã', 'café'),
             ('Almoço', 'almoço'),
             ('Jantar', 'jantar')

--- a/rasa/actions/notifications/buttons_notification.py
+++ b/rasa/actions/notifications/buttons_notification.py
@@ -7,8 +7,8 @@ from rasa_core.actions.action import Action
 TELEGRAM_ACCESS_TOKEN = os.getenv('TELEGRAM_ACCESS_TOKEN', '')
 FACEBOOK_ACCESS_TOKEN = os.getenv('FACEBOOK_ACCESS_TOKEN', '')
 
-TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', 'localhost')
-FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', 'localhost')
+TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', '')
+FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', '')
 
 class ActionButtonsNotification(Action):
     def name(self):
@@ -30,8 +30,8 @@ class ActionButtonsNotification(Action):
             ('Café da Manhã', 'café'),
             ('Almoço', 'almoço'),
             ('Jantar', 'jantar')
-        ]  
-    
+        ]
+
     def build_facebook_message(self, sender_id, message, buttons):
         return {
             'recipient': {
@@ -67,7 +67,7 @@ class ActionButtonsNotification(Action):
         values = self.build_button_dict()
         lista = [values[x:x+3]for x in range(0, len(values), 3)]
         print(lista)
-        for value in lista: 
+        for value in lista:
             for i in range(0, len(value)):
                 value[i] = {
                     'type': 'postback',
@@ -79,7 +79,7 @@ class ActionButtonsNotification(Action):
     def build_buttons_telegram(self):
         values = self.build_button_dict()
         lista = [values[x:x+3]for x in range(0, len(values), 3)]
-        for value in lista: 
+        for value in lista:
             for i in range(0, len(value)):
                 value[i] = {
                     'title': value[i][0],

--- a/rasa/actions/notifications/buttons_notification.py
+++ b/rasa/actions/notifications/buttons_notification.py
@@ -15,26 +15,68 @@ class ActionButtonsNotification(Action):
         return "action_buttons_notification"
 
     def run(self, dispatcher, tracker, domain):
-        buttons = self.build_button_telegram()
-        mensagem = 'VAI TOMAR NO CU'
-        dispatcher.utter_button_message(mensagem, buttons, button_type="custom")
+        buttons = self.build_buttons_telegram()
+        mensagem = 'SHABLAW'
+        buttons = self.build_buttons_facebook()
+        elements = self.build_facebook_elements(buttons)
+        dispatcher.utter_custom_message(*elements)
         return []
 
     def build_button_dict(self):
         return [
-            ('cardápio diario','dia'),
-            ('cardápio semanal', 'semana'),
-            ('alerta da comunidade', 'comunidade'),
-            ('café da manhã', 'café'),
-            ('jantar', 'jantar'),
-            ('almoço', 'almoço')
-        ]
-        
+            ('Alerta da Comunidade', 'alerta da comunidade'),
+            ('Cardápio Diario','dia'),
+            ('Cardápio Semanal', 'semana'),
+            ('Café da Manhã', 'café'),
+            ('Almoço', 'almoço'),
+            ('Jantar', 'jantar')
+        ]  
     
-    def build_button_facebook(self):
-        pass
-    
-    def build_button_telegram(self):
+    def build_facebook_message(self, sender_id, message, buttons):
+        return {
+            'recipient': {
+                'id': sender_id
+            },
+            'message': {
+                'text': message,
+                'attachment': {
+                    'type': 'template',
+                    'payload': {
+                        'template_type': 'generic',
+                        'elements': self.build_facebook_elements(buttons)
+                    }
+                }
+            }
+        }
+
+    def build_facebook_elements(self, buttons):
+        message = 'Qual das opções você deseja?'
+        elements = []
+        for value in buttons:
+            element = self.build_element(value, message)
+            elements.append(element)
+        return elements
+
+    def build_element(self, list_buttons, message):
+        return {
+            'title': message,
+            'buttons': list_buttons
+        }
+
+    def build_buttons_facebook(self):
+        values = self.build_button_dict()
+        lista = [values[x:x+3]for x in range(0, len(values), 3)]
+        print(lista)
+        for value in lista: 
+            for i in range(0, len(value)):
+                value[i] = {
+                    'type': 'postback',
+                    'title': value[i][0],
+                    'payload': value[i][1]
+                }
+        return lista
+
+    def build_buttons_telegram(self):
         values = self.build_button_dict()
         lista = [values[x:x+3]for x in range(0, len(values), 3)]
         for value in lista: 
@@ -44,11 +86,3 @@ class ActionButtonsNotification(Action):
                     'payload': value[i][1]
                 }
         return lista
-
-
-
-
-        
-
-
-    

--- a/rasa/actions/notifications/buttons_notification.py
+++ b/rasa/actions/notifications/buttons_notification.py
@@ -1,0 +1,54 @@
+import os
+from pymongo import MongoClient
+from rasa_core.actions.action import Action
+
+# If you want to use your own bot to development add the bot token as
+# second parameters
+TELEGRAM_ACCESS_TOKEN = os.getenv('TELEGRAM_ACCESS_TOKEN', '')
+FACEBOOK_ACCESS_TOKEN = os.getenv('FACEBOOK_ACCESS_TOKEN', '')
+
+TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', 'localhost')
+FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', 'localhost')
+
+class ActionButtonsNotification(Action):
+    def name(self):
+        return "action_buttons_notification"
+
+    def run(self, dispatcher, tracker, domain):
+        buttons = self.build_button_telegram()
+        mensagem = 'VAI TOMAR NO CU'
+        dispatcher.utter_button_message(mensagem, buttons, button_type="custom")
+        return []
+
+    def build_button_dict(self):
+        return [
+            ('cardápio diario','dia'),
+            ('cardápio semanal', 'semana'),
+            ('alerta da comunidade', 'comunidade'),
+            ('café da manhã', 'café'),
+            ('jantar', 'jantar'),
+            ('almoço', 'almoço')
+        ]
+        
+    
+    def build_button_facebook(self):
+        pass
+    
+    def build_button_telegram(self):
+        values = self.build_button_dict()
+        lista = [values[x:x+3]for x in range(0, len(values), 3)]
+        for value in lista: 
+            for i in range(0, len(value)):
+                value[i] = {
+                    'title': value[i][0],
+                    'payload': value[i][1]
+                }
+        return lista
+
+
+
+
+        
+
+
+    

--- a/rasa/actions/notifications/register_notification.py
+++ b/rasa/actions/notifications/register_notification.py
@@ -23,6 +23,7 @@ class ActionRegisterNotification(Action):
 
         text = tracker_state['latest_message']['text']
 
+        text = text.lower()
         words_list = text.split(' ')
         words_key_list = self.build_key_words()
 
@@ -35,17 +36,17 @@ class ActionRegisterNotification(Action):
 
         user_telegram = self.check_telegram_valid_user(sender_id)
         user_facebook = self.check_facebook_valid_user(sender_id)
-
+        welcome = 'Agora você já pode receber notificações desse tipo!'
         if user_telegram != {}:
             self.update_telegram_user(user_telegram, notification)
-            messages.append('Agora você já pode receber notificações desse tipo!')
+            messages.append(welcome)
         elif user_facebook != {}:
             self.update_facebook_user(user_facebook, notification)
-            messages.append('Agora você já pode receber notificações desse tipo!')
+            messages.append(welcome)
         else:
             messages.append(('Não consegui te encontrar aqui!'
-                            'Tô com alguns problemas e não'
-                            'consegui te cadastrar!'))
+                             'Tô com alguns problemas e não'
+                             'consegui te cadastrar!'))
 
         for message in messages:
             dispatcher.utter_message(message)
@@ -103,7 +104,6 @@ class ActionRegisterNotification(Action):
     def update_notification(self, notification, URI, database, user):
         client = MongoClient(URI)
         db = client[database]
-
         notification_list = user['notification']
 
         for element in notification_list:

--- a/rasa/actions/notifications/register_notification.py
+++ b/rasa/actions/notifications/register_notification.py
@@ -7,8 +7,8 @@ from rasa_core.actions.action import Action
 TELEGRAM_ACCESS_TOKEN = os.getenv('TELEGRAM_ACCESS_TOKEN', '')
 FACEBOOK_ACCESS_TOKEN = os.getenv('FACEBOOK_ACCESS_TOKEN', '')
 
-TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', 'localhost')
-FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', 'localhost')
+TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', '')
+FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', '')
 
 
 class ActionRegisterNotification(Action):
@@ -38,10 +38,14 @@ class ActionRegisterNotification(Action):
 
         if user_telegram != {}:
             self.update_telegram_user(user_telegram, notification)
-        else:
+            messages.append('Agora você já pode receber notificações desse tipo!')
+        elif user_facebook != {}:
             self.update_facebook_user(user_facebook, notification)
-
-        messages.append('Agora você já pode receber notificações desse tipo!')
+            messages.append('Agora você já pode receber notificações desse tipo!')
+        else:
+            messages.append(('Não consegui te encontrar aqui!'
+                            'Tô com alguns problemas e não'
+                            'consegui te cadastrar!'))
 
         for message in messages:
             dispatcher.utter_message(message)
@@ -127,7 +131,7 @@ class ActionRegisterNotification(Action):
             return user
 
     def check_facebook_valid_user(self, sender_id):
-        client = MongoClient(TELEGRAM_DB_URI)
+        client = MongoClient(FACEBOOK_DB_URI)
         db_facebook = client['lino_facebook']
 
         user = {}

--- a/rasa/actions/notifications/start.py
+++ b/rasa/actions/notifications/start.py
@@ -9,8 +9,8 @@ from rasa_core.actions.action import Action
 TELEGRAM_ACCESS_TOKEN = os.getenv('TELEGRAM_ACCESS_TOKEN', '')
 FACEBOOK_ACCESS_TOKEN = os.getenv('FACEBOOK_ACCESS_TOKEN', '')
 
-TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', 'localhost')
-FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', 'localhost')
+TELEGRAM_DB_URI = os.getenv('TELEGRAM_DB_URI', '')
+FACEBOOK_DB_URI = os.getenv('FACEBOOK_DB_URI', '')
 
 
 class ActionStart(Action):

--- a/rasa/data/intents/general.md
+++ b/rasa/data/intents/general.md
@@ -17,6 +17,8 @@
 - Oi
 - Olá
 - Iae
+- eai
+- eae
 - Fala meu compatriota
 - KKK eae man
 - Olar

--- a/rasa/data/intents/notifications.md
+++ b/rasa/data/intents/notifications.md
@@ -37,6 +37,7 @@
 - Me cadastra pra receber o café da manhã
 - Quero receber sobre o café da manhã
 - notificações café da manhã
+- café
 - café da manhã
 - café pretty please
 - quero me cadastrar pra lista de notificações do café da manhã
@@ -73,6 +74,7 @@
 - Me cadastra pra receber o cardápio do dia
 - Quero receber sobre o cardápio do dia
 - notificações cardápio do dia
+- dia
 - cardápio do dia
 - cardápio do dia pretty please
 - quero me cadastrar pra lista de notificações do cardápio do dia
@@ -85,6 +87,7 @@
 - Me cadastra pra receber o cardápio da semana
 - Quero receber sobre o cardápio da semana
 - notificações cardápio da semana
+- semana
 - cardápio da semana
 - cardápio da semana pretty please
 - quero me cadastrar pra lista de notificações do cardápio da semana

--- a/rasa/data/intents/notifications.md
+++ b/rasa/data/intents/notifications.md
@@ -94,3 +94,5 @@
 - show, quero receber o cardápio da semana
 - xuxu beleza, quero o cardápio da semana
 - opa, cardápio da semana então
+- comunidade
+- alerta da comunidade

--- a/rasa/data/stories/main.md
+++ b/rasa/data/stories/main.md
@@ -34,6 +34,7 @@
 ## path_register_notification
 * asks_about_notifications
   - utter_notifications
+  - action_buttons_notification
 * register_notification
   - custom_start
   - action_register_notification

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -42,7 +42,7 @@ actions:
   - utter_notifications
   - actions.notifications.start.ActionStart
   - actions.notifications.register_notification.ActionRegisterNotification
-
+  - actions.notifications.buttons_notification.ActionButtonsNotification
   - utter_documents
 
   - utter_gmail
@@ -87,9 +87,10 @@ templates:
         E aê, beleza?! Lino aqui!
 
         Que que vc tá afim hj? Documentos, período de matrícula, notificações ou RU?
-
+  
   utter_goodbye:
     - text: |
         Feshow então!!!
 
         Precisando, só me gritar aqui
+

--- a/rasa/email_notifier.py
+++ b/rasa/email_notifier.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import requests
+import os
+import time
+from pymongo import MongoClient
+
+telegram_token = os.getenv('ACCESS_TOKEN', '')
+PAGE_ACCESS_TOKEN = os.getenv('FACEBOOK_ACCESS_TOKEN', '')
+
+URL = os.getenv('WEBHOOK_URL', '')
+
+
+def getTelegramUsers():
+    client = MongoClient('mongodb://mongo-telegram:27010/lino_telegram')
+    db = client['lino_telegram']
+
+    users = db.users.find({"notification": {"description": "gmail alert",
+                           "value": True}}, {'_id': 0, 'sender_id': 1})
+    return users
+
+
+def getFacebookUsers():
+    client = MongoClient('mongodb://mongo-facebook:27011/lino_facebook')
+    db = client['lino_facebook']
+
+    users = db.users.find({"notification": {"description": "gmail alert",
+                           "value": True}}, {'_id': 0, 'sender_id': 1})
+    return users
+
+
+def getEmail():
+    response = requests.get(URL).json()
+    return response
+
+
+def parseJson(response):
+    message = ""
+    if response == "Forbidden":
+        message = ""
+    elif response == "No new messages found":
+        message = ""
+    else:
+        message = 'Vocẽ recebeu e-mail. Dá uma olhada aí' + '\n' + '\n' + \
+                str(response['email']) + '\n' + 'Assunto: ' + \
+                str(response['subject']) + '\n' + 'Mensagem: ' + \
+                str(response['message'])
+    return message
+
+
+def notifyTelegram(message):
+    chats = getTelegramUsers()
+    if chats is None:
+        return
+
+    for id in chats:
+        requests.get(
+            'https://api.telegram.org/bot{}/sendChatAction?chat_id='
+            .format(telegram_token, id) +
+            '{}&action=typing'.format(id)
+        )
+
+        time.sleep(1)
+
+        requests.get(
+            'https://api.telegram.org/bot{}/sendMessage?chat_id={}&text={}'
+            .format(telegram_token, id, str(message))).json()
+
+
+def notifyFacebook(message):
+    chats = getFacebookUsers()
+    if chats is None:
+        return
+
+    for user in chats:
+        requests.get(
+            'https://graph.facebook.com/v2.6/{}/messages?access_token={}'
+            .format(user['sender_id'], PAGE_ACCESS_TOKEN)
+        )
+
+
+result = getEmail()
+response = parseJson(result)
+notifyTelegram(str(response))
+notifyFacebook(str(response))


### PR DESCRIPTION
## Descrição 

Cria botões para auxiliar o usuário ao realizar o registro das notificações do Lino, possibilitando registrar-se para o recebimento das:

- notificações do cardápio do dia
- notificações do cardápio da semana
- notificações do cardápio do café da manhã
- notificações do cardápio do almoço
- notificações do cardápio do jantar
- notificações da comunidade acadêmica

## Resolve (Issues)

#170 

## Notas pessoais sobre o PR

Está sendo feita a tentativa de reaproveitar o código proporcionado no rasa, a respeito do envio de mensagens relacionadas aos mensageiros utilizados, que seriam o Telegram e o Facebook.