### PR TITLE
Refatora botões das notificações no Facebook

### DIFF
--- a/rasa/actions/notifications/buttons_notification.py
+++ b/rasa/actions/notifications/buttons_notification.py
@@ -40,8 +40,8 @@ class ActionButtonsNotification(Action):
         if not buttons_telegram and not buttons_facebook:
             dispatcher.utter_message(('Tive alguns problemas aqui em encontrar'
                                      ' os tipos de notificações :(...'))
-            dispatcher.utter_message(('Vou tentar arrumar o mais rápido '
-                                     'possível pra te mandar algumas, pode ser?'))
+            dispatcher.utter_message(('Vou tentar arrumar rapidão aqui pra te '
+                                     'mandar as que eu tinha antes, beleza?'))
             dispatcher.utter_message(('Você precisa de mais alguma outra coisa'
                                      ' além disso? Só pedir :)'))
 

--- a/rasa/actions/notifications/buttons_notification.py
+++ b/rasa/actions/notifications/buttons_notification.py
@@ -24,16 +24,26 @@ class ActionButtonsNotification(Action):
             dispatcher.utter_button_message(message,
                                             buttons_telegram,
                                             button_type="custom")
-        except ValueError as valueException:
-            print(valueException + ': on Telegram')
+        except Exception as exception:
+            print(exception)
+            buttons_telegram = None
 
         if not buttons_telegram:
             try:
                 buttons_facebook = self.build_buttons_facebook()
                 elements = self.build_facebook_elements(buttons_facebook)
                 dispatcher.utter_custom_message(*elements)
-            except ValueError as valueException:
-                print(valueException + ': on Messenger')
+            except Exception as exception:
+                print(exception)
+                buttons_facebook = None
+
+        if not buttons_telegram and not buttons_facebook:
+            dispatcher.utter_message(('Tive alguns problemas aqui em encontrar'
+                                     ' os tipos de notificações :(...'))
+            dispatcher.utter_message(('Vou tentar arrumar o mais rápido '
+                                     'possível pra te mandar algumas, pode ser?'))
+            dispatcher.utter_message(('Você precisa de mais alguma outra coisa'
+                                     ' além disso? Só pedir :)'))
 
         return []
 
@@ -48,27 +58,12 @@ class ActionButtonsNotification(Action):
             ('Jantar', 'jantar')
         ]
 
-    def build_facebook_message(self, sender_id, message, buttons):
-        return {
-            'recipient': {
-                'id': sender_id
-            },
-            'message': {
-                'text': message,
-                'attachment': {
-                    'type': 'template',
-                    'payload': {
-                        'template_type': 'generic',
-                        'elements': self.build_facebook_elements(buttons)
-                    }
-                }
-            }
-        }
-
     def build_facebook_elements(self, buttons):
         message = 'Qual das opções você deseja?'
         elements = []
         for value in buttons:
+            print('A'*100)
+            print(value)
             element = self.build_element(value, message)
             elements.append(element)
         return elements

--- a/rasa/actions/notifications/register_notification.py
+++ b/rasa/actions/notifications/register_notification.py
@@ -34,24 +34,63 @@ class ActionRegisterNotification(Action):
                 notification = self.get_element_in_notification_map(word)
                 break
 
+        if notification is "":
+            dispatcher.utter_message(('Não consegui encontrar essa opção!'
+                                      'Dá uma olhada melhor nas opções, '
+                                      'só temos elas, ainda!'))
+            return []
+
+        user_checked = False
+
         user_telegram = self.check_telegram_valid_user(sender_id)
         user_facebook = self.check_facebook_valid_user(sender_id)
         welcome = 'Agora você já pode receber notificações desse tipo!'
         if user_telegram != {}:
-            self.update_telegram_user(user_telegram, notification)
-            messages.append(welcome)
-        elif user_facebook != {}:
-            self.update_facebook_user(user_facebook, notification)
-            messages.append(welcome)
-        else:
-            messages.append(('Não consegui te encontrar aqui!'
-                             'Tô com alguns problemas e não'
-                             'consegui te cadastrar!'))
+            user_checked = self.check_user_receive_notification(
+                sender_id, TELEGRAM_DB_URI, 'lino_telegram', notification)
 
-        for message in messages:
-            dispatcher.utter_message(message)
+            if user_checked:
+                self.update_telegram_user(user_telegram, notification)
+                messages.append(welcome)
+
+        elif user_facebook != {}:
+            user_checked = self.check_user_receive_notification(
+                sender_id, FACEBOOK_DB_URI, 'lino_facebook', notification)
+
+            if user_checked:
+                self.update_facebook_user(user_facebook, notification)
+                messages.append(welcome)
+
+        if user_checked:
+            for message in messages:
+                dispatcher.utter_message(message)
+        else:
+            dispatcher.utter_message(('Você já recebe esse tipo de '
+                                     'notificação...'))
 
         return []
+
+    def check_user_receive_notification(
+            self, sender_id, URI, database, notification):
+
+        client = MongoClient(URI)
+        db = client[database]
+
+        user_notifications = db.users.find_one(
+            {'sender_id': sender_id},
+            {'_id': 0, 'notification': 1}
+        )
+
+        notifications = user_notifications['notification']
+
+        notification_stats = False
+
+        for element in notifications:
+            if element['description'] is notification and not element['value']:
+                notification_stats = True
+                break
+
+        return notification_stats
 
     def build_key_words(self):
         return [


### PR DESCRIPTION
## Descrição 

Foi realizada a refatoração para mostrar os botões das notificações aos usuários do facebook. Além disso, foi refatorado os métodos de verificação no banco de dados para analisar se o usuário escolheu uma notificação já cadastrada.

## Resolve (Issues)

#192 