### PR TITLE
Refatora fluxo de despedida

### DIFF
--- a/rasa/data/intents/general.md
+++ b/rasa/data/intents/general.md
@@ -48,6 +48,47 @@
 - Volto depois
 - Tchau, obrigado
 - falous
+- vlw flw
+- flw vlw
 - massa, agr tchau
 - brigadão
 - valeu, agora tchau
+- tchau, lino
+- hasta la vista baby
+- goodbye
+- hasta la vista
+- adeus
+- au revoir
+- sayonara goodbye
+- hasta luego
+- tchau, bebe
+- valeu falou
+- falou valeu
+- see ya
+- chau
+- xau
+- pica a mula
+- tchau bjs
+- bjs lino
+- beijos
+- até logo
+- arrivederci
+- tchauzinho
+- que a porta bata onde o sol não bate
+- inté
+- tchaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaau
+- see ya later, aligator
+- see you
+- bye nii
+- é nois
+- noixx
+- é tois
+- tóis
+- tois
+- bjs bb
+- falou consagrado
+- falou compatriota
+- cabou
+- falou meu informado
+- tchau meu informante
+- cabou o semestre

--- a/rasa/data/stories/main.md
+++ b/rasa/data/stories/main.md
@@ -5,6 +5,7 @@
 ## path_goodbye
 * goodbye
   - utter_goodbye
+  - utter_restart
 
 ## path_fallback
 * out_of_scope

--- a/rasa/data/stories/main.md
+++ b/rasa/data/stories/main.md
@@ -5,7 +5,6 @@
 ## path_goodbye
 * goodbye
   - utter_goodbye
-  - utter_restart
 
 ## path_fallback
 * out_of_scope

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -66,7 +66,7 @@ templates:
 
   utter_restart:
     - text: |
-        Vou reiniciar o flow aqui
+
 
   utter_menu:
     - text: |

--- a/rasa/domain.yml
+++ b/rasa/domain.yml
@@ -102,3 +102,14 @@ templates:
 
         Precisando, só me gritar aqui
 
+    - text: |
+        Tchau, tchau
+
+        Estarei aqui quando precisar
+
+    - text: |
+        Flwss!
+
+        Espero te ver novamente em breve
+
+        Até logo!!!


### PR DESCRIPTION
## Descrição 

Este PR tem o objetivo de refatorar o fluxo de despedida do Lino, de maneira que ele aceite mais intents e reinicie o fluxo de conversa, sem avisar ao usuário para não haver overflow de mensagens.

## Resolve (Issues)

#200 